### PR TITLE
Geocoding Fix

### DIFF
--- a/src/FarhanWazir/GoogleMaps/GMaps.php
+++ b/src/FarhanWazir/GoogleMaps/GMaps.php
@@ -2370,7 +2370,7 @@ class GMaps
             }
         }
 
-        $data_location = "https://maps.google.com/maps/api/geocode/json?address=".urlencode(utf8_encode($address))."&sensor=".$this->sensor;
+        $data_location = "https://maps.google.com/maps/api/geocode/json?address=".urlencode(utf8_encode($address))."&sensor=".$this->sensor."&key=".$this->apiKey;
         if ($this->region != "" && strlen($this->region) == 2) {
             $data_location .= "&region=".$this->region;
         }


### PR DESCRIPTION
For some reason, geocoding stopped working. Lat, long coordinates are always returning 0, 0. This used to only happen sometimes but is now happening all the time. I'm not sure what changes Google Maps have made.

Add apiKey to get_lat_long_from_address method fixes the issue.